### PR TITLE
Refactor to use parseDocument()

### DIFF
--- a/lib/read-string.js
+++ b/lib/read-string.js
@@ -2,6 +2,7 @@
 
 const { Readable } = require('stream');
 const YAML = require('yaml');
+const { YAMLMap, YAMLSeq } = require('yaml/types');
 
 const yamlAndContentsFromStream = require('./yaml-and-contents-from-stream');
 
@@ -20,16 +21,17 @@ function readString(string) {
 
       // don't parse empty front matter
       if (yamlFMContents.length !== 0) {
-        try {
-          fmYaml = YAML.parse(yamlFMContents);
-        } catch(err) {
-          throw new Error(`Error parsing YAML in front matter\n\n${err.message}`);
+        const fmDoc = YAML.parseDocument(yamlFMContents);
+        if (fmDoc.errors && fmDoc.errors.length !== 0) {
+          throw new Error(`Error parsing YAML in front matter`);
         }
 
-        // check here the it's an object of key/value at top level
-        if (typeof fmYaml === null || Array.isArray(fmYaml) || typeof fmYaml !== 'object') {
+        // check here that it's a key/value map at top level
+        if (!(fmDoc.contents instanceof YAMLMap)) {
           throw new Error('Top level should be an object');
         }
+
+        fmYaml = fmDoc.toJSON();
       }
 
       fmYaml._contents = otherContents;

--- a/tests/read-string-test.js
+++ b/tests/read-string-test.js
@@ -36,7 +36,6 @@ describe('read-string', () => {
   it('no front matter', () => {
     return testReadString(
 'no front matter here',
-// TODO: test the contents?
 {
   _contents: 'no front matter here',
 },


### PR DESCRIPTION
instead of parse()

This means it's an easier check if it's a map at the top level, and I will be able to provide better error messages, maybe.